### PR TITLE
Deprecate listenUris in favour of baseUri

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -14,7 +14,7 @@ if($LASTEXITCODE -ne 0) { exit 1 }
 
 $branch = @{ $true = $env:APPVEYOR_REPO_BRANCH; $false = $(git symbolic-ref --short -q HEAD) }[$env:APPVEYOR_REPO_BRANCH -ne $NULL];
 $revision = @{ $true = "{0:00000}" -f [convert]::ToInt32("0" + $env:APPVEYOR_BUILD_NUMBER, 10); $false = "local" }[$env:APPVEYOR_BUILD_NUMBER -ne $NULL];
-$suffix = @{ $true = ""; $false = "$($branch.Substring(0, [math]::Min(10,$branch.Length)))-$revision"}[$branch -eq "master" -and $revision -ne "local"]
+$suffix = @{ $true = ""; $false = "$($branch.Substring(0, [math]::Min(10,$branch.Length)).Replace("/", "-"))-$revision"}[$branch -eq "master" -and $revision -ne "local"]
 
 echo "build: Version suffix is $suffix"
 

--- a/src/Seq.Apps/Apps/Host.cs
+++ b/src/Seq.Apps/Apps/Host.cs
@@ -15,6 +15,11 @@ namespace Seq.Apps
         [Obsolete("Use the Host(baseUri, instanceName) constructor.")]
         public Host(string[] listenUris, string instanceName)
         {
+            if (listenUris == null || listenUris.Length == 0)
+            {
+                throw new ArgumentException("At least 1 listen uri must be given.", nameof(listenUris));
+            }
+
             InstanceName = instanceName;
             ListenUris = listenUris;
             BaseUri = listenUris[0];
@@ -27,13 +32,12 @@ namespace Seq.Apps
         /// <param name="baseUri">The base URI that the server can be accessed on.</param>
         public Host(string baseUri, string instanceName)
         {
+            BaseUri = baseUri ?? throw new ArgumentNullException(nameof(baseUri));
             InstanceName = instanceName;
 
             #pragma warning disable 612, 618 // Obsolete
             ListenUris = new [] { baseUri };
-            #pragma warning restore 612, 618
-
-            BaseUri = baseUri;
+            #pragma warning restore 612, 618            
         }
 
         /// <summary>

--- a/src/Seq.Apps/Apps/Host.cs
+++ b/src/Seq.Apps/Apps/Host.cs
@@ -1,4 +1,6 @@
-﻿namespace Seq.Apps
+﻿using System;
+
+namespace Seq.Apps
 {
     /// <summary>
     /// Represents the Seq instance running the app.
@@ -10,10 +12,28 @@
         /// </summary>
         /// <param name="instanceName">The name of the Seq instance, or null.</param>
         /// <param name="listenUris">The URIs at which the server is listening.</param>
+        [Obsolete("Use the Host(baseUri, instanceName) constructor.")]
         public Host(string[] listenUris, string instanceName)
         {
             InstanceName = instanceName;
             ListenUris = listenUris;
+            BaseUri = listenUris[0];
+        }
+        
+        /// <summary>
+        /// Create a <see cref="Host"/>.
+        /// </summary>
+        /// <param name="instanceName">The name of the Seq instance, or null.</param>
+        /// <param name="baseUri">The base URI that the server can be accessed on.</param>
+        public Host(string baseUri, string instanceName)
+        {
+            InstanceName = instanceName;
+
+            #pragma warning disable 612, 618 // Obsolete
+            ListenUris = new [] { baseUri };
+            #pragma warning restore 612, 618
+
+            BaseUri = baseUri;
         }
 
         /// <summary>
@@ -24,6 +44,12 @@
         /// <summary>
         /// The URIs at which the server is listening.
         /// </summary>
+        [Obsolete("Use BaseUri.")]
         public string[] ListenUris { get; }
+
+        /// <summary>
+        /// The base URI that the server can be accessed on.
+        /// </summary>
+        public string BaseUri { get; }
     }
 }


### PR DESCRIPTION
Adds a single `BaseUri` property to `Host` that should always provide a base url for the seq instance, that may not be the same as the uris Seq is listening on.

This subtly changes the behaviour of the obsolete constructor to throw if there isn't at least 1 listen uri. We might want to keep the old behaviour instead.