### PR TITLE
SeqAppSettingAttribute.IsInvocationParameter

### DIFF
--- a/src/Seq.Apps/Apps/SeqAppSettingAttribute.cs
+++ b/src/Seq.Apps/Apps/SeqAppSettingAttribute.cs
@@ -31,5 +31,19 @@ namespace Seq.Apps
         /// the type of the property.
         /// </summary>
         public SettingInputType InputType { get; set; }
+
+        /// <summary>
+        /// If set to <c>true</c>, the setting should be considered an invocation
+        /// parameter (as opposed to a purely configuration-time setting). Typical
+        /// invocation parameters include things like destination email addresses,
+        /// notification channels, message queue names, and so-on.
+        /// </summary>
+        /// <remarks>
+        /// At configuration-time, the Seq administrator can still decide to deny
+        /// user overrides of the parameter, or select other parameters to be user-
+        /// overridable. This setting provides an interface hint so that appropriate
+        /// invocation parameters can be selected by default.
+        /// </remarks>
+        public bool IsInvocationParameter { get; set; }
     }
 }


### PR DESCRIPTION
Add `IsInvocationParameter` to `SeqAppSettingAttribute`, to support default-overridable invocation parameters.

Usage:

```csharp
[SeqAppSetting(IsInvocationParameter = true)]
public string Channel { get; set; }
```

This change will not break older apps assemblies compiled against earlier versions of the library. Newer app versions that use this setting will need to run in a Seq server that has this option available.

Supports https://github.com/datalust/seq-tickets/issues/705.