### PR TITLE
Modernisation, support for CLEF input and output

### DIFF
--- a/src/Seq.Apps/Apps/App.cs
+++ b/src/Seq.Apps/Apps/App.cs
@@ -17,14 +17,10 @@ namespace Seq.Apps
         /// <param name="storagePath">A folder in which the app may store data.</param>
         public App(string id, string title, IReadOnlyDictionary<string, string> settings, string storagePath)
         {
-            if (id == null) throw new ArgumentNullException(nameof(id));
-            if (title == null) throw new ArgumentNullException(nameof(title));
-            if (settings == null) throw new ArgumentNullException(nameof(settings));
-            if (storagePath == null) throw new ArgumentNullException(nameof(storagePath));
-            Id = id;
-            Title = title;
-            Settings = settings;
-            StoragePath = storagePath;
+            Id = id ?? throw new ArgumentNullException(nameof(id));
+            Title = title ?? throw new ArgumentNullException(nameof(title));
+            Settings = settings ?? throw new ArgumentNullException(nameof(settings));
+            StoragePath = storagePath ?? throw new ArgumentNullException(nameof(storagePath));
         }
 
         /// <summary>

--- a/src/Seq.Apps/Apps/Host.cs
+++ b/src/Seq.Apps/Apps/Host.cs
@@ -35,9 +35,9 @@ namespace Seq.Apps
             BaseUri = baseUri ?? throw new ArgumentNullException(nameof(baseUri));
             InstanceName = instanceName;
 
-            #pragma warning disable 612, 618 // Obsolete
+#pragma warning disable 612, 618 // Obsolete
             ListenUris = new [] { baseUri };
-            #pragma warning restore 612, 618            
+#pragma warning restore 612, 618            
         }
 
         /// <summary>

--- a/src/Seq.Apps/Apps/IAppHost.cs
+++ b/src/Seq.Apps/Apps/IAppHost.cs
@@ -19,7 +19,7 @@ namespace Seq.Apps
         Host Host { get; }
 
         /// <summary>
-        /// A logger through which the app can raise events.
+        /// A logger through which the app can raise diagnostic events.
         /// </summary>
         ILogger Logger { get; }
 

--- a/src/Seq.Apps/Apps/IPublishJson.cs
+++ b/src/Seq.Apps/Apps/IPublishJson.cs
@@ -1,0 +1,25 @@
+﻿using System.IO;
+
+namespace Seq.Apps
+{
+    /// <summary>
+    /// When implemented by a <see cref="SeqApp"/>, the app will be treated as an input, and given the
+    /// opportunity to publish events back to Seq.
+    /// </summary>
+    public interface IPublishJson
+    {
+        /// <summary>
+        /// Start publishing events.
+        /// </summary>
+        /// <remarks>The app must synchronize its use of <paramref name="inputWriter"/> so that events
+        /// are not interleaved. The app should return immediately from this method call.</remarks>
+        /// <param name="inputWriter">A <see cref="TextWriter"/> through which the app can write newline-delimited, CLEF-formatted
+        /// JSON events for ingestion into Seq.</param>
+        void Start(TextWriter inputWriter);
+
+        /// <summary>
+        /// Called when the app should stop publishing events. This call should block until publishing is stopped.
+        /// </summary>
+        void Stop();
+    }
+}

--- a/src/Seq.Apps/Apps/ISubscribeTo.cs
+++ b/src/Seq.Apps/Apps/ISubscribeTo.cs
@@ -1,7 +1,7 @@
 ﻿namespace Seq.Apps
 {
     /// <summary>
-    /// Subscribes a reactor to a typed event.
+    /// Subscribes an app to a typed event.
     /// </summary>
     /// <typeparam name="TData">The type representing event data.</typeparam>
     public interface ISubscribeTo<TData>

--- a/src/Seq.Apps/Apps/ISubscribeToJsonAsync.cs
+++ b/src/Seq.Apps/Apps/ISubscribeToJsonAsync.cs
@@ -3,16 +3,15 @@
 namespace Seq.Apps
 {
     /// <summary>
-    /// Subscribes a app to a typed event, with the event handled asynchronously.
+    /// Subscribes an app to events formatted as CLEF JSON, with the event handled asynchronously.
     /// </summary>
-    /// <typeparam name="TData">The type representing event data.</typeparam>
-    public interface ISubscribeToAsync<TData>
+    public interface ISubscribeToJsonAsync
     {
         /// <summary>
         /// Invoked when an event is sent to a reactor.
         /// </summary>
-        /// <param name="evt">The event.</param>
+        /// <param name="json">The event, formatted as CLEF JSON.</param>
         /// <returns>A <see cref="Task"/> that will complete when the app has finished handling the event.</returns>
-        Task OnAsync(Event<TData> evt);
+        Task OnAsync(string json);
     }
 }

--- a/src/Seq.Apps/Apps/Reactor.cs
+++ b/src/Seq.Apps/Apps/Reactor.cs
@@ -1,52 +1,25 @@
 ﻿using System;
-using Serilog;
 
 namespace Seq.Apps
 {
     /// <summary>
     /// A reactor is an object that reacts to events.
     /// </summary>
-    public abstract class Reactor
+    [Obsolete("Derive from SeqApp instead")]
+    public abstract class Reactor : SeqApp
     {
-        IAppHost _host;
-
         /// <summary>
         /// Attach the reactor instance to the host.
         /// </summary>
         /// <param name="host">The host running the reactor.</param>
-        public void Attach(IAppHost host)
+        public new void Attach(IAppHost host)
         {
-            _host = host;
-            OnAttached();
+            base.Attach(host);
         }
-
-        /// <summary>
-        /// The app to which the reactor belongs.
-        /// </summary>
-        protected App App => _host.App;
-
-        /// <summary>
-        /// The Seq instance running the app.
-        /// </summary>
-        protected Host Host => _host.Host;
-
-        /// <summary>
-        /// A logger allowing the reactor to itself raise events.
-        /// </summary>
-        protected ILogger Log => _host.Logger;
 
         /// <summary>
         /// A folder in which the app may store data.
         /// </summary>
-        [Obsolete("Use App.StoragePath")]
-        protected string StoragePath => _host.App.StoragePath;
-
-        /// <summary>
-        /// Called after all configuration has completed, but before any
-        /// events are sent to the app.
-        /// </summary>
-        protected virtual void OnAttached()
-        {
-        }
+        protected string StoragePath => App.StoragePath;
     }
 }

--- a/src/Seq.Apps/Apps/SeqApp.cs
+++ b/src/Seq.Apps/Apps/SeqApp.cs
@@ -1,0 +1,50 @@
+﻿using Serilog;
+
+namespace Seq.Apps
+{
+    /// <summary>
+    /// A Seq app; the app can subscribe to events by implementing <see cref="ISubscribeTo{TData}"/> or
+    /// <see cref="ISubscribeToAsync{TData}"/>, or produce events by implementing <see cref="IPublishJson"/>.
+    /// </summary>
+    /// <remarks>Apps are hosted in a single-threaded manner: initialization and event firing and disposal are
+    /// performed on the same thread. Apps themselves may maintain captive threads for ingestion and
+    /// interact with the host's logger, if required.</remarks>
+    public abstract class SeqApp
+    {
+        IAppHost _host;
+
+        /// <summary>
+        /// Attach the app instance to the host.
+        /// </summary>
+        /// <param name="host">The host running the reactor.</param>
+        public void Attach(IAppHost host)
+        {
+            _host = host;
+            OnAttached();
+        }
+
+        /// <summary>
+        /// The app to which the instance belongs.
+        /// </summary>
+        protected App App => _host.App;
+
+        /// <summary>
+        /// The Seq instance running the app.
+        /// </summary>
+        protected Host Host => _host.Host;
+
+        /// <summary>
+        /// A logger allowing the app raise diagnostic events.
+        /// </summary>
+        protected ILogger Log => _host.Logger;
+        
+        /// <summary>
+        /// Called after all configuration has completed, but before any
+        /// events are sent to the app and before ingestion begins. The
+        /// app should use this event to validate its configuration.
+        /// </summary>
+        protected virtual void OnAttached()
+        {
+        }
+    }
+}

--- a/src/Seq.Apps/Apps/SeqApp.cs
+++ b/src/Seq.Apps/Apps/SeqApp.cs
@@ -3,7 +3,7 @@
 namespace Seq.Apps
 {
     /// <summary>
-    /// A Seq app; the app can subscribe to events by implementing <see cref="ISubscribeTo{TData}"/> or
+    /// A Seq app; the app can subscribe to events by implementing <see cref="ISubscribeToJsonAsync"/>, <see cref="ISubscribeTo{TData}"/>, or
     /// <see cref="ISubscribeToAsync{TData}"/>, or produce events by implementing <see cref="IPublishJson"/>.
     /// </summary>
     /// <remarks>Apps are hosted in a single-threaded manner: initialization and event firing and disposal are

--- a/src/Seq.Apps/Seq.Apps.csproj
+++ b/src/Seq.Apps/Seq.Apps.csproj
@@ -11,7 +11,7 @@
     <PackageTags>seq</PackageTags>
     <PackageIconUrl>https://getseq.net/images/seq-nuget.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/datalust/seq-apps-runtime</PackageProjectUrl>
-    <PackageLicenseUrl>http://www.apache.org/licenses/LICENSE-2.0</PackageLicenseUrl>
+    <PackageLicenseUrl>http://www.apache.org/licenses/LICENSE-2.0</PackageLicenseUrl>    
   </PropertyGroup>
   
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net4.5.2' ">

--- a/src/Seq.Apps/Seq.Apps.csproj
+++ b/src/Seq.Apps/Seq.Apps.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net4.5.2;netstandard2.0</TargetFrameworks>
-    <VersionPrefix>5.0.0</VersionPrefix>
+    <VersionPrefix>5.1.0</VersionPrefix>
     <RootNamespace>Seq</RootNamespace>
     <GenerateXmlDocumentation>true</GenerateXmlDocumentation>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>


### PR DESCRIPTION
This changeset paves the way for C#-based apps to publish events (as inputs), allows apps to subscribe to events as CLEF-formatted JSON instead of the opinionated `Event<TData>` structure, and effectively renames `Reactor` to `SeqApp`, to make the terminology less confusing.

A type called `Reactor: SeqApp` is included, and some hoops are jumped through, so that existing apps will continue to be hostable in Seq 5.1+. Apps that are based on the new version of this library should continue to work in Seq versions earlier than 5.1, if new features aren't used.

Some verification is going to be needed to ensure the loader will accept having virtual members like `Reactor.App`, `Reactor.Host` and `Reactor.Logger` moved into the new base class in all cases.