### PR TITLE
Add Syntax to SeqAppSettingAttribute

### DIFF
--- a/src/Seq.Apps/Apps/SeqAppSettingAttribute.cs
+++ b/src/Seq.Apps/Apps/SeqAppSettingAttribute.cs
@@ -45,5 +45,15 @@ namespace Seq.Apps
         /// invocation parameters can be selected by default.
         /// </remarks>
         public bool IsInvocationParameter { get; set; }
+        
+        /// <summary>
+        /// If the setting value contains code in a programming or markup language, the
+        /// language name. The Seq UI may choose fonts and syntax highlighting accordingly.
+        /// </summary>
+        /// <remarks>Valid names are a subset of the names and aliases recognized by
+        /// <a href="https://github.com/github/linguist/blob/master/lib/linguist/languages.yml">GitHub
+        /// Linguist</a>. Use the generic value <c>code</c> if the language is non-specific but
+        /// the value should be displayed in fixed-width font.</remarks>
+        public string Syntax { get; set; }
     }
 }

--- a/src/Seq.Apps/Seq.Apps.csproj
+++ b/src/Seq.Apps/Seq.Apps.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net4.5.2;netstandard2.0</TargetFrameworks>
-    <VersionPrefix>5.1.1</VersionPrefix>
+    <VersionPrefix>5.2.0</VersionPrefix>
     <RootNamespace>Seq</RootNamespace>
     <GenerateXmlDocumentation>true</GenerateXmlDocumentation>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>


### PR DESCRIPTION
The aim is to (eventually) improve the editing experience for markup and code in the Seq app UI.

Before this can happen:

 - [ ] This PR will need to be published
 - [ ] `seqcli app define` will need an update
 - [ ] Seq itself will need an update
